### PR TITLE
Rename FirmwareUpdater to FirmwareUploader

### DIFF
--- a/.github/workflows/check-certificates.yml
+++ b/.github/workflows/check-certificates.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   get-certificates-list:
     # This workflow would fail in forks that don't have the certificate secrets defined
-    if: github.repository == 'arduino/FirmwareUpdater'
+    if: github.repository == 'arduino/FirmwareUploader'
     runs-on: ubuntu-latest
     outputs:
       certificates: ${{ steps.get-files.outputs.certificates }}
@@ -38,7 +38,7 @@ jobs:
 
   check-certificates:
     # This workflow would fail in forks that don't have the certificate secrets defined
-    if: github.repository == 'arduino/FirmwareUpdater'
+    if: github.repository == 'arduino/FirmwareUploader'
     runs-on: ubuntu-latest
     needs: get-certificates-list
 

--- a/.github/workflows/check-notarization-certificates.yml
+++ b/.github/workflows/check-notarization-certificates.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   check-certificates:
     # This workflow would fail in forks that don't have the certificate secrets defined
-    if: github.repository == 'arduino/FirmwareUpdater'
+    if: github.repository == 'arduino/FirmwareUploader'
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/link-validation.yml
+++ b/.github/workflows/link-validation.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   verify-links:
     # Don't trigger on schedule event when in a fork
-    if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository == 'arduino/FirmwareUpdater')
+    if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository == 'arduino/FirmwareUploader')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,10 +87,10 @@ jobs:
         # Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
         run: |
           TAG=${GITHUB_REF/refs\/tags\//}
-          tar cjf dist/FirmwareUpdater_${TAG}_macOS_64bit.tar.bz2 \
+          tar cjf dist/FirmwareUploader_${TAG}_macOS_64bit.tar.bz2 \
           firmwares \
           LICENSE.txt \
-          -C dist/macos64/ FirmwareUpdater
+          -C dist/macos64/ FirmwareUploader
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
@@ -141,4 +141,4 @@ jobs:
           bodyFile: "dist/CHANGELOG.md"
           draft: false
           prerelease: ${{ steps.prerelease.outputs.IS_PRE }}
-          artifacts: dist/FirmwareUpdater*,dist/package_index.json
+          artifacts: dist/FirmwareUploader*,dist/package_index.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /debug
-/FirmwareUpdater*
+/FirmwareUploader*
 /.vscode/
 .idea
 coverage_*.txt

--- a/README.md
+++ b/README.md
@@ -58,14 +58,13 @@ Usage of ./FirmwareUploader:
 
 ## How to build the tools from source file
 
-To build we use [task](https://taskfile.dev/) for simplicity.
-From the sources root directory run:
+To build we use [task](https://taskfile.dev/) for simplicity. From the sources root directory run:
 
 ```
 task dist:<OS>_<ARCH>
 ```
-Where <OS> could be one of: `macOS`,`Windows`,`Linux`
-And <ARCH>: `32bit`, `64bit`, `ARM` or `ARM64`
+
+Where <OS> could be one of: `macOS`,`Windows`,`Linux`. And <ARCH>: `32bit`, `64bit`, `ARM` or `ARM64`
 
 This will create the `FirmwareUploader` executable.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Use this tool to update the firmware and/or add SSL certificates for any WINC, N
 
 You can download the Firmware/Certificates updater here:
 
-https://github.com/arduino/FirmwareUpdater/releases/latest
+https://github.com/arduino/FirmwareUploader/releases/latest
 
 ## Usage
 
@@ -90,4 +90,4 @@ details.
 You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to the
 Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-[security-policy]: https://github.com/arduino/FirmwareUpdater/security/policy
+[security-policy]: https://github.com/arduino/FirmwareUploader/security/policy

--- a/README.md
+++ b/README.md
@@ -13,27 +13,27 @@ https://github.com/arduino/FirmwareUpdater/releases/latest
 Extract the zip file and run (for example, NINA -> WiFi1010)
 
 ```
-./$your_os/updater -flasher firmwares/NINA/FirmwareUpdater.mkrwifi1010.ino.bin -firmware firmwares/NINA/1.2.1/NINA_W102.bin -port /dev/ttyACM0  -address arduino.cc:443 -restore_binary /tmp/arduino_build_619137/WiFiSSLClient.ino.bin -programmer {runtime.tools.bossac}/bossac
+./FirmwareUploader -flasher firmwares/NINA/FirmwareUpdater.mkrwifi1010.ino.bin -firmware firmwares/NINA/1.2.1/NINA_W102.bin -port /dev/ttyACM0 -address arduino.cc:443 -restore_binary /tmp/arduino_build_619137/WiFiSSLClient.ino.bin -programmer {runtime.tools.bossac}/bossac
 ```
 
 To flash a MKR1000:
 
 ```
-./$your_os/updater -flasher firmwares/WINC1500/FirmwareUpdater.mkr1000.ino.bin -firmware firmwares/WINC1500/19.5.4/m2m_aio_3a0.bin -port /dev/ttyACM0  -address arduino.cc:443 -restore_binary /tmp/arduino_build_619137/WiFiSSLClient.ino.bin -programmer {runtime.tools.bossac}/bossac
+./FirmwareUploader -flasher firmwares/WINC1500/FirmwareUpdater.mkr1000.ino.bin -firmware firmwares/WINC1500/19.5.4/m2m_aio_3a0.bin -port /dev/ttyACM0 -address arduino.cc:443 -restore_binary /tmp/arduino_build_619137/WiFiSSLClient.ino.bin -programmer {runtime.tools.bossac}/bossac
 ```
 
 To update a MKRNB1500:
 
 ```
-./$your_os/updater -flasher firmwares/SARA/SerialSARAPassthrough.ino.bin -firmware firmwares/SARA/5.6A2.00-to-5.6A2.01.pkg -port /dev/ttyACM0 -restore_binary firmwares/SARA/SerialSARAPassthrough.ino.bin -programmer {runtime.tools.bossac}/bossac
+./FirmwareUploader -flasher firmwares/SARA/SerialSARAPassthrough.ino.bin -firmware firmwares/SARA/5.6A2.00-to-5.6A2.01.pkg -port /dev/ttyACM0 -restore_binary firmwares/SARA/SerialSARAPassthrough.ino.bin -programmer {runtime.tools.bossac}/bossac
 ```
 
 ### Command line options
 
-The full list of command line options can be obtained with the `-h` option: `./updater -h`
+The full list of command line options can be obtained with the `-h` option: `./FirmwareUploader -h`
 
 ```
-Usage of ./distrib/linux64/updater:
+Usage of ./FirmwareUploader:
   -address value
       address (host:port) to fetch and flash root certificate for, multiple values allowed
   -certs string
@@ -41,9 +41,11 @@ Usage of ./distrib/linux64/updater:
   -firmware string
       firmware file to flash
   -flasher string
-      firmware upload binary (precompiled for the right target) -> if not provided it will expect FirmwareUpdater sketch to be already flashed on the board
+      firmware upload binary (precompiled for the right target)
+  -get_available_for string
+      Ask for available firmwares matching a given board
   -model string
-      module model (winc or nina)
+      module model (winc, nina or sara)
   -port string
       serial port to use for flashing
   -programmer string
@@ -51,18 +53,21 @@ Usage of ./distrib/linux64/updater:
   -read
       read all firmware and output to stdout
   -restore_binary string
-      firmware upload binary (precompiled for the right target) -> if not provided it will try to restore the original firmware
+      firmware upload binary (precompiled for the right target)
 ```
 
 ## How to build the tools from source file
 
+To build we use [task](https://taskfile.dev/) for simplicity.
 From the sources root directory run:
 
 ```
-go build -o updater
+task dist:<OS>_<ARCH>
 ```
+Where <OS> could be one of: `macOS`,`Windows`,`Linux`
+And <ARCH>: `32bit`, `64bit`, `ARM` or `ARM64`
 
-This will create the `updater` executable.
+This will create the `FirmwareUploader` executable.
 
 ## Security
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -71,9 +71,9 @@ vars:
   LDFLAGS: >
     -ldflags
     '
-    -X github.com/arduino/FirmwareUpdater/version.versionString={{.VERSION}}
-    -X github.com/arduino/FirmwareUpdater/version.commit={{ .COMMIT }}
-    -X github.com/arduino/FirmwareUpdater/version.date={{.TIMESTAMP}}
+    -X github.com/arduino/FirmwareUploader/version.versionString={{.VERSION}}
+    -X github.com/arduino/FirmwareUploader/version.commit={{ .COMMIT }}
+    -X github.com/arduino/FirmwareUploader/version.date={{.TIMESTAMP}}
     '
   # test vars
   GOFLAGS: "-timeout 10m -v -coverpkg=./... -covermode=atomic"
@@ -82,9 +82,9 @@ vars:
   TEST_LDFLAGS: >
     -ldflags
     '
-    -X github.com/arduino/FirmwareUpdater/version.versionString={{.TEST_VERSION}}
-    -X github.com/arduino/FirmwareUpdater/version.commit={{.TEST_COMMIT}}
-    -X github.com/arduino/FirmwareUpdater/version.date={{.TIMESTAMP}}
+    -X github.com/arduino/FirmwareUploader/version.versionString={{.TEST_VERSION}}
+    -X github.com/arduino/FirmwareUploader/version.commit={{.TEST_COMMIT}}
+    -X github.com/arduino/FirmwareUploader/version.date={{.TIMESTAMP}}
     '
   # check-lint vars
   GOLINTBIN:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -56,7 +56,7 @@ tasks:
       - npx {{ .PRETTIER }} --write "**/*.{yml,yaml}"
 
 vars:
-  PROJECT_NAME: "FirmwareUpdater"
+  PROJECT_NAME: "FirmwareUploader"
   DIST_DIR: "dist"
   # build vars
   COMMIT:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/arduino/FirmwareUpdater
+module github.com/arduino/FirmwareUploader
 
 go 1.14
 

--- a/gon.config.hcl
+++ b/gon.config.hcl
@@ -1,5 +1,5 @@
-source = ["dist/macos64/FirmwareUpdater"]
-bundle_id = "cc.arduino.FirmwareUpdater"
+source = ["dist/macos64/FirmwareUploader"]
+bundle_id = "cc.arduino.FirmwareUploader"
 
 sign {
   application_identity = "Developer ID Application: ARDUINO SA (7KT7ZWMCJT)"
@@ -8,5 +8,5 @@ sign {
 # Ask Gon for zip output to force notarization process to take place.
 # The CI will ignore the zip output, using the signed binary only.
 zip {
-  output_path = "FirmwareUpdater.zip"
+  output_path = "FirmwareUploader.zip"
 }

--- a/main.go
+++ b/main.go
@@ -8,11 +8,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/arduino/FirmwareUpdater/modules/nina"
-	"github.com/arduino/FirmwareUpdater/modules/sara"
-	"github.com/arduino/FirmwareUpdater/modules/winc"
-	"github.com/arduino/FirmwareUpdater/utils"
-	"github.com/arduino/FirmwareUpdater/utils/context"
+	"github.com/arduino/FirmwareUploader/modules/nina"
+	"github.com/arduino/FirmwareUploader/modules/sara"
+	"github.com/arduino/FirmwareUploader/modules/winc"
+	"github.com/arduino/FirmwareUploader/utils"
+	"github.com/arduino/FirmwareUploader/utils/context"
 )
 
 var ctx context.Context

--- a/modules/nina/flasher.go
+++ b/modules/nina/flasher.go
@@ -26,7 +26,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/arduino/FirmwareUpdater/utils"
+	"github.com/arduino/FirmwareUploader/utils"
 	"go.bug.st/serial"
 )
 

--- a/modules/nina/main.go
+++ b/modules/nina/main.go
@@ -28,9 +28,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/arduino/FirmwareUpdater/programmers/avrdude"
-	"github.com/arduino/FirmwareUpdater/programmers/bossac"
-	"github.com/arduino/FirmwareUpdater/utils/context"
+	"github.com/arduino/FirmwareUploader/programmers/avrdude"
+	"github.com/arduino/FirmwareUploader/programmers/bossac"
+	"github.com/arduino/FirmwareUploader/utils/context"
 )
 
 var f *Flasher

--- a/modules/sara/flasher.go
+++ b/modules/sara/flasher.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/arduino/FirmwareUpdater/utils"
+	"github.com/arduino/FirmwareUploader/utils"
 	"go.bug.st/serial"
 )
 

--- a/modules/sara/main.go
+++ b/modules/sara/main.go
@@ -21,8 +21,8 @@ package sara
 
 import (
 	"fmt"
-	"github.com/arduino/FirmwareUpdater/programmers/bossac"
-	"github.com/arduino/FirmwareUpdater/utils/context"
+	"github.com/arduino/FirmwareUploader/programmers/bossac"
+	"github.com/arduino/FirmwareUploader/utils/context"
 	"io/ioutil"
 	"log"
 	"strconv"

--- a/modules/winc/flasher.go
+++ b/modules/winc/flasher.go
@@ -25,7 +25,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/arduino/FirmwareUpdater/utils"
+	"github.com/arduino/FirmwareUploader/utils"
 	"go.bug.st/serial"
 )
 

--- a/modules/winc/main.go
+++ b/modules/winc/main.go
@@ -28,8 +28,8 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/arduino/FirmwareUpdater/programmers/bossac"
-	"github.com/arduino/FirmwareUpdater/utils/context"
+	"github.com/arduino/FirmwareUploader/programmers/bossac"
+	"github.com/arduino/FirmwareUploader/utils/context"
 )
 
 var f *Flasher

--- a/programmers/avrdude/avrdude.go
+++ b/programmers/avrdude/avrdude.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/arduino/FirmwareUpdater/utils/context"
+	"github.com/arduino/FirmwareUploader/utils/context"
 	"github.com/arduino/arduino-cli/executils"
 	"github.com/pkg/errors"
 )

--- a/programmers/bossac/bossac.go
+++ b/programmers/bossac/bossac.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/arduino/FirmwareUpdater/utils/context"
+	"github.com/arduino/FirmwareUploader/utils/context"
 	"github.com/arduino/arduino-cli/arduino/serialutils"
 	"github.com/arduino/arduino-cli/executils"
 	"github.com/pkg/errors"


### PR DESCRIPTION
Updated binary name (from FirmwareUpdater to FirmwareUploader) in the CI / Taskfiles / .gitignore.
I think it's a bit confusing to use both FirmwareUploader and FirmwareUpdater in the same GitHub repo though.. I've renamed also the repo handle. The only thing missing is to rename the repo name in settings.
