### PR TITLE
fix CI not setting executable permission to mac binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,9 @@ jobs:
       - name: Re-package binary and update checksum
         # Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
         run: |
+          # GitHub's upload/download-artifact@v2 actions don't preserve file permissions,
+          # so we need to add execution permission back.
+          chmod +x dist/macos64/FirmwareUploader
           TAG=${GITHUB_REF/refs\/tags\//}
           tar cjf dist/FirmwareUploader_${TAG}_macOS_64bit.tar.bz2 \
           firmwares \


### PR DESCRIPTION
The mac binary (version 0.1.4) does not have executable permission. This PR fixes this behavior.
Just like in the [arduino-cli](https://github.com/arduino/arduino-cli/blob/master/.github/workflows/release.yaml#L87)