### PR TITLE
Add script to generate json containing information to run fwuploader tool

### DIFF
--- a/generator/generator.py
+++ b/generator/generator.py
@@ -6,7 +6,7 @@ import hashlib
 import shutil
 from pathlib import Path
 
-DOWNLOAD_URL = "https://downloads.arduino.cc"
+DOWNLOAD_URL = "https://downloads.arduino.cc/arduino-fwuploader"
 FQBNS = {
     "mkr1000": "arduino:samd:mkr1000",
     "mkrwifi1010": "arduino:samd:mkrwifi1010",
@@ -240,10 +240,12 @@ if __name__ == "__main__":
 
     boards_json = generate_boards_json(raw_boards, args.arduino_cli)
 
-    with open("boards.json", "w") as f:
+    Path("boards").mkdir()
+
+    with open("boards/board_index.json", "w") as f:
         json.dump(boards_json, f, indent=2)
 
-# boards.json must be formatted like so:
+# board_index.json must be formatted like so:
 #
 # {
 #     "name": "MKR 1000",

--- a/generator/generator.py
+++ b/generator/generator.py
@@ -1,0 +1,144 @@
+import json
+import hashlib
+import shutil
+from pathlib import Path
+
+DOWNLOAD_URL = "https://downloads.arduino.cc"
+FQBNS = {
+    "mkr1000": "arduino:samd:mkr1000",
+    "mkrwifi1010": "arduino:samd:mkrwifi1010",
+    "nano_33_iot": "arduino:samd:nano_33_iot",
+    "mkrvidor4000": "arduino:samd:mkrvidor4000",
+    "uno2018": "arduino:megaavr:uno2018",
+    "mkrnb1500": "arduino:samd:mkrnb1500",
+    "nanorp2040connect": "arduino:mbed_nano:nanorp2040connect",
+}
+
+
+# Generates file SHA256
+def sha2(file_path):
+    with open(file_path, "rb") as f:
+        return hashlib.sha256(f.read()).hexdigest()
+
+
+# Generate and copy loader Sketch binary data for specified board
+def create_loader_data(simple_fqbn, binary):
+    loader_path = f"firmwares/loader/{simple_fqbn}/loader.bin"
+    loader = Path(__file__).parent / loader_path
+    loader.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(binary, loader)
+
+    file_hash = sha2(loader)
+
+    return {
+        "url": f"{DOWNLOAD_URL}/{loader_path}",
+        "checksum": f"SHA-256:{file_hash}",
+        "size": f"{loader.stat().st_size}",
+    }
+
+
+# Generate and copy all firmware binary data for specified board
+def create_firmware_data(simple_fqbn, binary, module, version):
+    binary_name = binary.name
+    firmware_path = f"firmwares/{module}/{version}/{binary_name}"
+    firmware = Path(__file__).parent / firmware_path
+    firmware.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(binary, firmware)
+
+    file_hash = sha2(firmware)
+
+    return {
+        "version": version,
+        "url": f"{DOWNLOAD_URL}/{firmware_path}",
+        "checksum": f"SHA-256:{file_hash}",
+        "size": f"{firmware.stat().st_size}",
+    }
+
+
+def generate_boards_json(input_data):
+    boards = {
+        "arduino:samd:mkr1000": {"fqbn": "arduino:samd:mkr1000", "firmware": []},
+        "arduino:samd:mkrwifi1010": {
+            "fqbn": "arduino:samd:mkrwifi1010",
+            "firmware": [],
+        },
+        "arduino:samd:nano_33_iot": {
+            "fqbn": "arduino:samd:nano_33_iot",
+            "firmware": [],
+        },
+        "arduino:samd:mkrvidor4000": {
+            "fqbn": "arduino:samd:mkrvidor4000",
+            "firmware": [],
+        },
+        "arduino:megaavr:uno2018": {"fqbn": "arduino:megaavr:uno2018", "firmware": []},
+        "arduino:samd:mkrnb1500": {"fqbn": "arduino:samd:mkrnb1500", "firmware": []},
+        "arduino:mbed_nano:nanorp2040connect": {
+            "fqbn": "arduino:mbed_nano:nanorp2040connect",
+            "firmware": [],
+        },
+    }
+
+    for pseudo_fqbn, data in input_data.items():
+        fqbn = FQBNS[pseudo_fqbn]
+        simple_fqbn = fqbn.replace(":", ".")
+
+        for _, v in data.items():
+            item = v[0]
+            binary = Path(item["Path"])
+
+            if item["IsLoader"]:
+                boards[fqbn]["loader_sketch"] = create_loader_data(simple_fqbn, binary)
+            else:
+                module, version = item["version"].split("/")
+                boards[fqbn]["firmware"].append(
+                    create_firmware_data(simple_fqbn, binary, module, version)
+                )
+
+    # TODO: Run arduino-cli to get board names and other things?
+
+    boards_json = []
+    for _, b in boards.items():
+        boards_json.append(b)
+
+
+if __name__ == "__main__":
+    # raw_boards.json has been generated using --get_available_for FirmwareUploader flag.
+    # It has been edited a bit to better handle parsing.
+    with open("raw_boards.json", "r") as f:
+        raw_boards = json.load(f)
+
+    boards_json = generate_boards_json(raw_boards)
+
+    with open("boards.json", "w") as f:
+        json.dump(boards_json, f, indent=2)
+
+# boards.json must be formatted like so:
+#
+# {
+#     "name": "MKR 1000",
+#     "fqbn": "arduino:samd:mkr1000",
+#     "module": "WINC_1500",
+#     "firmware": [
+#         {
+#             "version": "19.6.1",
+#             "url": "https://downloads.arduino.cc/firmwares/WINC_1500/19.6.1/m2m_aio_3a0.bin",
+#             "checksum": "SHA-256:de0c6b1621aa15996432559efb5d8a29885f62bde145937eee99883bfa129f97",
+#             "size": "359356",
+#         },
+#         {
+#             "version": "19.5.4",
+#             "url": "https://downloads.arduino.cc/firmwares/WINC_1500/19.5.4/m2m_aio_3a0.bin",
+#             "checksum": "SHA-256:71e5a805e60f96e6968414670d8a414a03cb610fd4b020f47ab53f5e1ff82a13",
+#             "size": "413604",
+#         },
+#     ],
+#     "loader_sketch": {
+#         "url": "https://downloads.arduino.cc/firmwares/loader/arduino.samd.mkr1000/loader.bin",
+#         "checksum": "SHA-256:71e5a805e60f96e6968414670d8a414a03cb610fd4b020f47ab53f5e1ff82a13",
+#         "size": "39287",
+#     },
+#     "uploader": "arduino:bossac@1.7.0",
+#     "uploader.command": "{uploader} --port={upload.port} -U true -i -e -w -v {loader.sketch} -R",
+#     "uploader.requires_1200_bps_touch": "true",
+#     "uploader.requires_port_change": "true",
+# }

--- a/generator/raw_boards.json
+++ b/generator/raw_boards.json
@@ -1,0 +1,528 @@
+{
+  "mkr1000": {
+    "/home/alien/workspace/FirmwareUploader/firmwares/WINC1500": [
+      {
+        "version": "WINC1500",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/WINC1500/FirmwareUpdater.mkr1000.ino.bin",
+        "Name": "firmwares WINC1500",
+        "IsLoader": true
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/WINC1500/19.4.4": [
+      {
+        "version": "WINC1500/19.4.4",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/WINC1500/19.4.4/m2m_aio_3a0.bin",
+        "Name": "WINC1500 19.4.4",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/WINC1500/19.5.2": [
+      {
+        "version": "WINC1500/19.5.2",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/WINC1500/19.5.2/m2m_aio_3a0.bin",
+        "Name": "WINC1500 19.5.2",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/WINC1500/19.5.4": [
+      {
+        "version": "WINC1500/19.5.4",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/WINC1500/19.5.4/m2m_aio_3a0.bin",
+        "Name": "WINC1500 19.5.4",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/WINC1500/19.6.1": [
+      {
+        "version": "WINC1500/19.6.1",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/WINC1500/19.6.1/m2m_aio_3a0.bin",
+        "Name": "WINC1500 19.6.1",
+        "IsLoader": false
+      }
+    ]
+  },
+  "mkrwifi1010": {
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA": [
+      {
+        "version": "NINA",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/FirmwareUpdater.mkrwifi1010.ino.bin",
+        "Name": "firmwares NINA",
+        "IsLoader": true
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.0.0": [
+      {
+        "version": "NINA/1.0.0",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.0.0/NINA_W102.bin",
+        "Name": "NINA 1.0.0",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.1.0": [
+      {
+        "version": "NINA/1.1.0",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.1.0/NINA_W102.bin",
+        "Name": "NINA 1.1.0",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.1": [
+      {
+        "version": "NINA/1.2.1",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.1/NINA_W102.bin",
+        "Name": "NINA 1.2.1",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.2": [
+      {
+        "version": "NINA/1.2.2",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.2/NINA_W102.bin",
+        "Name": "NINA 1.2.2",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.3": [
+      {
+        "version": "NINA/1.2.3",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.3/NINA_W102.bin",
+        "Name": "NINA 1.2.3",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.4": [
+      {
+        "version": "NINA/1.2.4",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.4/NINA_W102.bin",
+        "Name": "NINA 1.2.4",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.3.0": [
+      {
+        "version": "NINA/1.3.0",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.3.0/NINA_W102.bin",
+        "Name": "NINA 1.3.0",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.0": [
+      {
+        "version": "NINA/1.4.0",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.0/NINA_W102.bin",
+        "Name": "NINA 1.4.0",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.1": [
+      {
+        "version": "NINA/1.4.1",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.1/NINA_W102.bin",
+        "Name": "NINA 1.4.1",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.2": [
+      {
+        "version": "NINA/1.4.2",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.2/NINA_W102.bin",
+        "Name": "NINA 1.4.2",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.3": [
+      {
+        "version": "NINA/1.4.3",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.3/NINA_W102.bin",
+        "Name": "NINA 1.4.3",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.4": [
+      {
+        "version": "NINA/1.4.4",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.4/NINA_W102.bin",
+        "Name": "NINA 1.4.4",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.5": [
+      {
+        "version": "NINA/1.4.5",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.5/NINA_W102.bin",
+        "Name": "NINA 1.4.5",
+        "IsLoader": false
+      }
+    ]
+  },
+  "nano_33_iot": {
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA": [
+      {
+        "version": "NINA",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/FirmwareUpdater.nano_33_iot.ino.bin",
+        "Name": "firmwares NINA",
+        "IsLoader": true
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.0.0": [
+      {
+        "version": "NINA/1.0.0",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.0.0/NINA_W102.bin",
+        "Name": "NINA 1.0.0",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.1.0": [
+      {
+        "version": "NINA/1.1.0",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.1.0/NINA_W102.bin",
+        "Name": "NINA 1.1.0",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.1": [
+      {
+        "version": "NINA/1.2.1",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.1/NINA_W102.bin",
+        "Name": "NINA 1.2.1",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.2": [
+      {
+        "version": "NINA/1.2.2",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.2/NINA_W102.bin",
+        "Name": "NINA 1.2.2",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.3": [
+      {
+        "version": "NINA/1.2.3",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.3/NINA_W102.bin",
+        "Name": "NINA 1.2.3",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.4": [
+      {
+        "version": "NINA/1.2.4",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.4/NINA_W102.bin",
+        "Name": "NINA 1.2.4",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.3.0": [
+      {
+        "version": "NINA/1.3.0",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.3.0/NINA_W102.bin",
+        "Name": "NINA 1.3.0",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.0": [
+      {
+        "version": "NINA/1.4.0",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.0/NINA_W102.bin",
+        "Name": "NINA 1.4.0",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.1": [
+      {
+        "version": "NINA/1.4.1",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.1/NINA_W102.bin",
+        "Name": "NINA 1.4.1",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.2": [
+      {
+        "version": "NINA/1.4.2",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.2/NINA_W102.bin",
+        "Name": "NINA 1.4.2",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.3": [
+      {
+        "version": "NINA/1.4.3",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.3/NINA_W102.bin",
+        "Name": "NINA 1.4.3",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.4": [
+      {
+        "version": "NINA/1.4.4",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.4/NINA_W102.bin",
+        "Name": "NINA 1.4.4",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.5": [
+      {
+        "version": "NINA/1.4.5",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.5/NINA_W102.bin",
+        "Name": "NINA 1.4.5",
+        "IsLoader": false
+      }
+    ]
+  },
+  "mkrvidor4000": {
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.0.0": [
+      {
+        "version": "NINA/1.0.0",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.0.0/NINA_W102.bin",
+        "Name": "NINA 1.0.0",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.1.0": [
+      {
+        "version": "NINA/1.1.0",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.1.0/NINA_W102.bin",
+        "Name": "NINA 1.1.0",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.1": [
+      {
+        "version": "NINA/1.2.1",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.1/NINA_W102.bin",
+        "Name": "NINA 1.2.1",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.2": [
+      {
+        "version": "NINA/1.2.2",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.2/NINA_W102.bin",
+        "Name": "NINA 1.2.2",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.3": [
+      {
+        "version": "NINA/1.2.3",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.3/NINA_W102.bin",
+        "Name": "NINA 1.2.3",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.4": [
+      {
+        "version": "NINA/1.2.4",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.4/NINA_W102.bin",
+        "Name": "NINA 1.2.4",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.3.0": [
+      {
+        "version": "NINA/1.3.0",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.3.0/NINA_W102.bin",
+        "Name": "NINA 1.3.0",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.0": [
+      {
+        "version": "NINA/1.4.0",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.0/NINA_W102.bin",
+        "Name": "NINA 1.4.0",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.1": [
+      {
+        "version": "NINA/1.4.1",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.1/NINA_W102.bin",
+        "Name": "NINA 1.4.1",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.2": [
+      {
+        "version": "NINA/1.4.2",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.2/NINA_W102.bin",
+        "Name": "NINA 1.4.2",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.3": [
+      {
+        "version": "NINA/1.4.3",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.3/NINA_W102.bin",
+        "Name": "NINA 1.4.3",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.4": [
+      {
+        "version": "NINA/1.4.4",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.4/NINA_W102.bin",
+        "Name": "NINA 1.4.4",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.5": [
+      {
+        "version": "NINA/1.4.5",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.5/NINA_W102.bin",
+        "Name": "NINA 1.4.5",
+        "IsLoader": false
+      }
+    ]
+  },
+  "uno2018": {
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA": [
+      {
+        "version": "NINA",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/FirmwareUpdater.unowifirev2.without_bl.ino.hex",
+        "Name": "firmwares NINA",
+        "IsLoader": true
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.1": [
+      {
+        "version": "NINA/1.2.1",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.1/NINA_W102-Uno_WiFi_Rev2.bin",
+        "Name": "NINA 1.2.1",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.2": [
+      {
+        "version": "NINA/1.2.2",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.2/NINA_W102-Uno_WiFi_Rev2.bin",
+        "Name": "NINA 1.2.2",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.3": [
+      {
+        "version": "NINA/1.2.3",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.3/NINA_W102-Uno_WiFi_Rev2.bin",
+        "Name": "NINA 1.2.3",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.4": [
+      {
+        "version": "NINA/1.2.4",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.2.4/NINA_W102-Uno_WiFi_Rev2.bin",
+        "Name": "NINA 1.2.4",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.3.0": [
+      {
+        "version": "NINA/1.3.0",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.3.0/NINA_W102-Uno_WiFi_Rev2.bin",
+        "Name": "NINA 1.3.0",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.0": [
+      {
+        "version": "NINA/1.4.0",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.0/NINA_W102-Uno_WiFi_Rev2.bin",
+        "Name": "NINA 1.4.0",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.1": [
+      {
+        "version": "NINA/1.4.1",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.1/NINA_W102-Uno_WiFi_Rev2.bin",
+        "Name": "NINA 1.4.1",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.2": [
+      {
+        "version": "NINA/1.4.2",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.2/NINA_W102-Uno_WiFi_Rev2.bin",
+        "Name": "NINA 1.4.2",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.3": [
+      {
+        "version": "NINA/1.4.3",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.3/NINA_W102-Uno_WiFi_Rev2.bin",
+        "Name": "NINA 1.4.3",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.4": [
+      {
+        "version": "NINA/1.4.4",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.4/NINA_W102-Uno_WiFi_Rev2.bin",
+        "Name": "NINA 1.4.4",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.5": [
+      {
+        "version": "NINA/1.4.5",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.5/NINA_W102-Uno_WiFi_Rev2.bin",
+        "Name": "NINA 1.4.5",
+        "IsLoader": false
+      }
+    ]
+  },
+  "mkrnb1500": {
+    "/home/alien/workspace/FirmwareUploader/firmwares/SARA": [
+      {
+        "version": "SARA",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/SARA/SerialSARAPassthrough.ino.bin",
+        "Name": "firmwares SARA",
+        "IsLoader": true
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/SARA/5.6A2.00-to-5.6A2.01": [
+      {
+        "version": "SARA/5.6A2.00-to-5.6A2.01",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/SARA/5.6A2_01/5.6A2.00-to-5.6A2.01.pkg",
+        "Name": "SARA 5.6A2_01 (5.6A2.00-to-5.6A2.01.pkg)",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/SARA/5.6A2_01_to_99": [
+      {
+        "version": "SARA/5.6A2_01_to_99",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/SARA/5.6A2_01/5.6A2_01_to_99.pkg",
+        "Name": "SARA 5.6A2_01 (5.6A2_01_to_99.pkg)",
+        "IsLoader": false
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/SARA/99_to_5.6A2_01": [
+      {
+        "version": "SARA/99_to_5.6A2_01",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/SARA/5.6A2_01/99_to_5.6A2_01.pkg",
+        "Name": "SARA 5.6A2_01 (99_to_5.6A2_01.pkg)",
+        "IsLoader": false
+      }
+    ]
+  },
+  "nanorp2040connect": {
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA": [
+      {
+        "version": "NINA",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/FirmwareUpdater.nanorp2040connect.ino.elf",
+        "Name": "firmwares NINA",
+        "IsLoader": true
+      }
+    ],
+    "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.5": [
+      {
+        "version": "NINA/1.4.5",
+        "Path": "/home/alien/workspace/FirmwareUploader/firmwares/NINA/1.4.5/NINA_W102-Nano_RP2040_Connect.bin",
+        "Name": "NINA 1.4.5",
+        "IsLoader": false
+      }
+    ]
+  }
+}


### PR DESCRIPTION
The `generator.py` script creates a `board_index.json` file that will be used by the FirmwareUploader tool to gather all the information necessary to run correctly, list of firmwares for each supported board, upload command to run, binary to loader Sketch. It also copies the necessary firmware and loader Sketch binaries in structured folders ready to be uploaded in the download server.

As of now it uses a `raw_board.json` file that has been created using some information obtained using the `--get_available_for` flag that returns all available firmware for all each supported board.

In the future we can use the `board_index.json` currently in use as a base and add new information if necessary.

The script assumes the Arduino CLI is installed and all supported boards' core too, it fails in case neither is found.

The script can be easily run like this:

```
cd generator
python generator.py -a <path_to_arduino_cli>
```

It must be run inside the `generator` folder where the `raw_boards.json` file is stored. All generated folders and files will be saved in that same folder.