### PR TITLE
[skip changelog] Change name of generated index json

### DIFF
--- a/generator/generator.py
+++ b/generator/generator.py
@@ -256,7 +256,7 @@ if __name__ == "__main__":
 
     Path("boards").mkdir()
 
-    with open("boards/board_index.json", "w") as f:
+    with open("boards/module_firmware_index.json", "w") as f:
         json.dump(boards_json, f, indent=2)
 
 # board_index.json must be formatted like so:


### PR DESCRIPTION
We chose another name for the json file that will contain the informations necessary for the `FirmwareUploader` to run correctly.