### PR TITLE
fix 🐛 causing panic with mkr1000

### DIFF
--- a/cli/certificates/flash.go
+++ b/cli/certificates/flash.go
@@ -21,6 +21,7 @@ package certificates
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -161,13 +162,16 @@ func run(cmd *cobra.Command, args []string) {
 
 	// Get flasher depending on which module to use
 	var f flasher.Flasher
-	switch board.Module {
+	moduleName := board.Module
+	switch moduleName {
 	case "NINA":
 		f, err = flasher.NewNinaFlasher(address)
 	case "SARA":
 		f, err = flasher.NewSaraFlasher(address)
-	case "WINC":
+	case "WINC1500":
 		f, err = flasher.NewWincFlasher(address)
+	default:
+		err = fmt.Errorf("unknown module: %s", moduleName)
 	}
 	if err != nil {
 		feedback.Errorf("Error during certificates flashing: %s", err)

--- a/cli/firmware/flash.go
+++ b/cli/firmware/flash.go
@@ -21,6 +21,7 @@ package firmware
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -193,8 +194,10 @@ func run(cmd *cobra.Command, args []string) {
 		f, err = flasher.NewNinaFlasher(address)
 	case "SARA":
 		f, err = flasher.NewSaraFlasher(address)
-	case "WINC":
+	case "WINC1500":
 		f, err = flasher.NewWincFlasher(address)
+	default:
+		err = fmt.Errorf("unknown module: %s", moduleName)
 	}
 	if err != nil {
 		feedback.Errorf("Error during firmware flashing: %s", err)


### PR DESCRIPTION
Solved a bug that caused a panic when a mkr1000 is used. The module name in `module_firmware_index.json` (WINC1500) was different from a check in the code (WINC)