### PR TITLE
harden the flashing process

### DIFF
--- a/cli/certificates/flash.go
+++ b/cli/certificates/flash.go
@@ -133,12 +133,17 @@ func run(cmd *cobra.Command, args []string) {
 	}
 
 	// Check if board needs a 1200bps touch for upload
+	uploadPort := address
 	if board.UploadTouch {
 		logrus.Info("Putting board into bootloader mode")
-		_, err := serialutils.Reset(address, board.UploadWait, nil)
+		newUploadPort, err := serialutils.Reset(address, board.UploadWait, nil)
 		if err != nil {
-			feedback.Errorf("Error during certificates flashing: missing board address")
+			feedback.Errorf("Error during firmware flashing: missing board address")
 			os.Exit(errorcodes.ErrGeneric)
+		}
+		if newUploadPort != "" {
+			logrus.Infof("Found port to upload Loader: %s", newUploadPort)
+			uploadPort = newUploadPort
 		}
 	}
 
@@ -164,11 +169,11 @@ func run(cmd *cobra.Command, args []string) {
 	moduleName := board.Module
 	switch moduleName {
 	case "NINA":
-		f, err = flasher.NewNinaFlasher(address)
+		f, err = flasher.NewNinaFlasher(uploadPort)
 	case "SARA":
-		f, err = flasher.NewSaraFlasher(address)
+		f, err = flasher.NewSaraFlasher(uploadPort)
 	case "WINC1500":
-		f, err = flasher.NewWincFlasher(address)
+		f, err = flasher.NewWincFlasher(uploadPort)
 	default:
 		err = fmt.Errorf("unknown module: %s", moduleName)
 	}

--- a/cli/certificates/flash.go
+++ b/cli/certificates/flash.go
@@ -162,7 +162,7 @@ func run(cmd *cobra.Command, args []string) {
 
 	// Wait a bit after flashing the loader sketch for the board to become
 	// available again.
-	time.Sleep(1 * time.Second)
+	time.Sleep(2 * time.Second)
 
 	// Get flasher depending on which module to use
 	var f flasher.Flasher

--- a/cli/certificates/flash.go
+++ b/cli/certificates/flash.go
@@ -138,7 +138,7 @@ func run(cmd *cobra.Command, args []string) {
 		logrus.Info("Putting board into bootloader mode")
 		newUploadPort, err := serialutils.Reset(address, board.UploadWait, nil)
 		if err != nil {
-			feedback.Errorf("Error during firmware flashing: missing board address")
+			feedback.Errorf("Error during certificates flashing: missing board address")
 			os.Exit(errorcodes.ErrGeneric)
 		}
 		if newUploadPort != "" {

--- a/cli/firmware/flash.go
+++ b/cli/firmware/flash.go
@@ -173,7 +173,6 @@ func run(cmd *cobra.Command, args []string) {
 			uploadPort = newUploadPort
 		}
 	}
-	// TODO use uploadPort instead of address
 
 	// Flash loader Sketch
 	programmerOut := new(bytes.Buffer)

--- a/cli/firmware/flash.go
+++ b/cli/firmware/flash.go
@@ -190,7 +190,7 @@ func run(cmd *cobra.Command, args []string) {
 
 	// Wait a bit after flashing the loader sketch for the board to become
 	// available again.
-	time.Sleep(1 * time.Second)
+	time.Sleep(2 * time.Second)
 
 	// Get flasher depending on which module to use
 	var f flasher.Flasher


### PR DESCRIPTION
It's possible, especially on Win, that the board changes port after a reset. Now the new port is used after resetting it.
I also incremented the waiting time between the loader flashing and the actual firmware update. The time was not sufficient for the board to be available again.