### PR TITLE
add back `--retries` flag 

### DIFF
--- a/cli/firmware/flash.go
+++ b/cli/firmware/flash.go
@@ -167,9 +167,8 @@ func run(cmd *cobra.Command, args []string) {
 		if err == nil {
 			logrus.Info("Operation completed: success! :-)")
 			break
-		} else {
-			feedback.Error(err)
 		}
+		feedback.Error(err)
 		if retry == int(retries) {
 			logrus.Fatal("Operation failed. :-(")
 		}
@@ -241,7 +240,6 @@ func updateFirmware(board *firmwareindex.IndexBoard, commandLine []string, modul
 	}
 	if err != nil {
 		flasherErr.Write([]byte(fmt.Sprintf("Error during firmware flashing: %s", err)))
-		return fmt.Errorf("error during firmware flashing: %s", err)
 	}
 
 	// Print the results
@@ -255,5 +253,8 @@ func updateFirmware(board *firmwareindex.IndexBoard, commandLine []string, modul
 			Stderr: flasherErr.String(),
 		}),
 	})
+	if err != nil {
+		return fmt.Errorf("error during firmware flashing: %s", err)
+	}
 	return nil
 }

--- a/cli/firmware/flash.go
+++ b/cli/firmware/flash.go
@@ -233,6 +233,7 @@ func run(cmd *cobra.Command, args []string) {
 		if err != nil {
 			feedback.Errorf("Error during firmware flashing: %s", err)
 			flasherErr.Write([]byte(fmt.Sprintf("Error during firmware flashing: %s", err)))
+			continue
 		}
 		f.Close()
 


### PR DESCRIPTION
Add `--retries` flag just like in #24.
We removed this behavior during the refactoring.
Basically, the FirmwareUploader tries to update the firmware 9 times in a row (by default). Sometimes there could be some failings because of programmer out of sync, serial port closing etc… With this flag, the process should be more reliable